### PR TITLE
Add 1 year max age cache control

### DIFF
--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -21,6 +21,7 @@ exports.handler = function(event, context, callback) {
 			statusCode: 200,
 			headers: {
 				'Content-Type': 'image/' + info.format,
+				'Cache-Control': 'max-age=31536000',
 			},
 			body: new Buffer(data).toString('base64'),
 			isBase64Encoded: true,


### PR DESCRIPTION
turns out we missed this, and it's not possible to force it at the cloudfront or api gateway level.