### PR TITLE
Add embed feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,16 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 						image.max();
 					}
 				}
+				
+				// embed
+				if ( args.embed ) {
+					args.embed =
+						typeof args.embed === 'string' 
+							? args.embed.split(',') 
+							: args.embed;
+					image.background(args.embed[0]);
+					image.embed();
+				}
 
 				// allow override of compression quality
 				if (args.webp) {


### PR DESCRIPTION
Sometimes we want the resultant image to be an exact size with the image resized like `fit` but with a background filling out to the w x h. sharp provides an embed() so this feature uses that.