### PR TITLE
Only adjust quality if the input is a JPG

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 							? Math.min(Math.max(Number(args.quality), 0), 100)
 							: 80,
 					});
-				} else if (args.quality) {
+				} else if (metadata.format === 'jpeg' && args.quality) {
 					image.jpeg({
 						quality: Math.min(
 							Math.max(Number(args.quality), 0),


### PR DESCRIPTION
Currently if you pass the `quality` argument to a PNG, you'll get back a JPEG, with things like no transparency.