### PR TITLE
Forward GIF requests directly to S3

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -1,5 +1,5 @@
 {
-	"Description": "Human Made Tachyon Image Server with Lambda v2.1.1",
+	"Description": "Human Made Tachyon Image Server with Lambda v2.1.2",
 	"Parameters": {
 		"NodeTachyonBucket" : {
 			"Type" : "String",
@@ -181,6 +181,20 @@
 						"TargetOriginId" : { "Ref" : "AWS::StackName" },
 						"ViewerProtocolPolicy" : "allow-all"
 					},
+					"CacheBehaviors" : [
+						{
+							"AllowedMethods" : [ "GET", "HEAD" ],
+							"CachedMethods" : [ "HEAD", "GET" ],
+							"ForwardedValues" : {
+								"QueryString" : "true",
+								"Headers" : [ "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers" ]
+							},
+							"PathPattern" : "*.gif",
+							"DefaultTTL" : "63115200",
+							"TargetOriginId" : "S3-Proxy",
+							"ViewerProtocolPolicy" : "allow-all"
+						}
+					],
 					"Enabled" : true,
 					"Origins" : [
 						{
@@ -197,6 +211,15 @@
 								}
 							],
 							"Id" : { "Ref" : "AWS::StackName" }
+						},
+						{
+							"DomainName" : { "Fn::Join" : [ "", [
+								{ "Ref" : "UploadsS3Bucket" }, ".s3.amazonaws.com"
+							] ] },
+							"Id" : "S3-Proxy",
+							"S3OriginConfig" : {
+
+							}
 						}
 					],
 					"CustomErrorResponses": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tachyon",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/humanmade/node-tachyon.git"


### PR DESCRIPTION
In the past we've detected Gifs in the Lambda function, and then passed them through - however this often hits the 6MB response limit from Lambda. GIFs are often large files, and until we are _actually_ resizing them, we should just forward the requests to S3. This means there's no limit in their size which is a lot better.