### PR TITLE
Zoom param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It's really that simple!
 |`crop_strategy`|String, "smart", "entropy", "attention"|There are 3 automatic cropping strategies for use with `resize`: <ul><li>`attention`: good results, ~70% slower</li><li>`entropy`: mediocre results, ~30% slower</li><li>`smart`: best results, ~50% slower</li>|
 |`fit`|String, "w,h"|A comma separated string of the target maximum width and height. Does not crop the image.|
 |`crop`|Boolean\|String, "x,y,w,h"|Crop an image by percentages x-offset, y-offset, width and height (x,y,w,h). Percentages are used so that you don’t need to recalculate the cropping when transforming the image in other ways such as resizing it. You can crop by pixel values too by appending `px` to the values. `crop=160px,160px,788px,788px` takes a 788 by 788 pixel square starting at 160 by 160.|
+|`zoom`|Number|Zooms the image by the specified amount for high DPI displays. `zoom=2` produces an image twice the size specified in `w`, `h`, `fit` or `resize`. The quality is automatically reduced to keep file sizes roughly equivalent to the non-zoomed image unless the `quality` argument is passed.|
 |`webp`|Boolean, 1|Force WebP format.|
 |`lb`|String, "w,h"|Add letterboxing effect to images, by scaling them to width, height while maintaining the aspect ratio and filling the rest with black or `background`.|
 |`background`|String|Add background color via name (red) or hex value (%23ff0000). Don't forget to escape # as `%23`.|

--- a/index.js
+++ b/index.js
@@ -178,17 +178,17 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 
 					// set default quality slightly higher than sharp's default
 					if ( ! args.quality ) {
-						args.quality = applyZoomCompression( 82.5, zoom );
+						args.quality = applyZoomCompression( 82, zoom );
 					}
 
 					// allow override of compression quality
 					if (args.webp) {
 						image.webp({
-							quality: Math.min(Math.max(Number(args.quality), 0), 100),
+							quality: Math.round(Math.min(Math.max(Number(args.quality), 0), 100)),
 						});
 					} else if (metadata.format === 'jpeg') {
 						image.jpeg({
-							quality: Math.min(Math.max(Number(args.quality), 0), 100),
+							quality: Math.round(Math.min(Math.max(Number(args.quality), 0), 100)),
 						});
 					}
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ var getDimArray = function( dims, zoom ) {
 	});
 }
 
+var clamp = function( val, min, max ) {
+	return Math.min( Math.max( Number( val ), min ), max );
+}
+
 module.exports.resizeBuffer = function(buffer, args, callback) {
 	return new Promise(function(resolve, reject) {
 		try {
@@ -173,7 +177,7 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 					// defaultValue = 100, zoom = 1.5; = 86
 					// defaultValue = 80, zoom = 1.5; = 68
 					var applyZoomCompression = function( defaultValue, zoom ) {
-						return Math.min(Math.max(Math.round( defaultValue - ( (Math.log(zoom) / Math.log(defaultValue / zoom)) * (defaultValue * zoom) ) ), Math.round(defaultValue / zoom)), defaultValue);
+						return clamp( Math.round( defaultValue - ( (Math.log(zoom) / Math.log(defaultValue / zoom)) * (defaultValue * zoom) ) ), Math.round(defaultValue / zoom), defaultValue );
 					}
 
 					// set default quality slightly higher than sharp's default
@@ -184,11 +188,11 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 					// allow override of compression quality
 					if (args.webp) {
 						image.webp({
-							quality: Math.round(Math.min(Math.max(Number(args.quality), 0), 100)),
+							quality: Math.round( clamp( args.quality, 0, 100 ) ),
 						});
 					} else if (metadata.format === 'jpeg') {
 						image.jpeg({
-							quality: Math.round(Math.min(Math.max(Number(args.quality), 0), 100)),
+							quality: Math.round( clamp( args.quality, 0, 100 ) ),
 						});
 					}
 


### PR DESCRIPTION
- Sets the default quality to 82% (same as WP)
- Adds default quality compression based on zoom to reduce file sizes if no quality arg set

Fixes #56 