### PR TITLE
Workaround bug in CloudFormation TTL for cloudfront

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -183,8 +183,8 @@
 							"QueryString" : "true"
 						},
 						"MinTTL" : 63115200,
-						"DefaultTTL": 63115200,
-						"MaxTTL": 63115200,
+						"DefaultTTL": 63115201,
+						"MaxTTL": 63115202,
 						"TargetOriginId" : { "Ref" : "AWS::StackName" },
 						"ViewerProtocolPolicy" : "allow-all",
 						"LambdaFunctionAssociations" : { "Fn::If" : [


### PR DESCRIPTION
It seems to be a new thing that CloudFormation won't accept a TTL for min / default / max that is all the same, seems like the comparisons are `!<` veresus `!<=`. This is easy enough to workaround without much upset.