### PR TITLE
Add local-api-gateway for testing locally with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y curl build-essential python2.7
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get -y install nodejs npm
+RUN apt-get update && apt-get -y install nodejs
 RUN ln -sf /usr/bin/python2.7 /usr/bin/python
 CMD cd /build ; npm install --production

--- a/local-api-gateway.js
+++ b/local-api-gateway.js
@@ -1,0 +1,38 @@
+const http = require('http');
+const url = require('url');
+const querystring = require('querystring');
+const {
+	spawn
+} = require('child_process');
+
+
+http.createServer(function (request, response) {
+	const bucket = 'hmn-uploads-eu';
+	const region = 'eu-west-1';
+	const task = __dirname;
+
+	const pathName = url.parse(request.url).pathname;
+	const query = url.parse(request.url).query;
+	const args = {
+		path: pathName,
+		queryStringParameters: querystring.parse( query ),
+		headers: request.headers,
+	};
+	const childArgs = ['run', '--rm', '-e', `S3_BUCKET=${ bucket }`, '-e', `S3_REGION=${ region }`, '-v', `${ task }:/var/task`, 'lambci/lambda:nodejs6.10', 'lambda-handler.handler', JSON.stringify(args)];
+	const child = spawn('docker', childArgs);
+	var stdout = '';
+	child.stdout.on('data', data => stdout += data);
+	child.stderr.on('data', data => console.warn(String(data)));
+	child.on('close', function () {
+		const lambdaExec = JSON.parse(stdout);
+		if ( lambdaExec.errorMessage ) {
+			response.writeHead( 500 );
+			response.write(JSON.stringify( lambdaExec ) );
+			response.end();
+			return;
+		}
+		response.writeHead(lambdaExec.statusCode, lambdaExec.headers);
+		response.write(Buffer.from(lambdaExec.body, 'base64'));
+		response.end();
+	});
+}).listen(7000);


### PR DESCRIPTION
This will let you test Tachyon running in the lambci docker image, via a web server (which is mimicking API Gateway). There's a simple node server that will basically exec docker with the task (just like we do in AWS).

Run with `node local-api-gateway.js` and access `http://localhost:7000/path/to/your/image/on/s3?w=100`