### PR TITLE
Fix Cloudformation stack creation TTL Error

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -208,7 +208,9 @@
 								"Headers" : [ "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers" ]
 							},
 							"PathPattern" : "*.gif",
-							"DefaultTTL" : "63115200",
+							"MinTTL" : 63115200,
+							"DefaultTTL": 63115201,
+							"MaxTTL": 63115202,
 							"TargetOriginId" : "S3-Proxy",
 							"ViewerProtocolPolicy" : "allow-all"
 						}


### PR DESCRIPTION
Cloudformation was erroring when setting the TTL for the cache behaviors.

When uploading through the cloudformation console it would complain that the TTLs are not int he right format.