### PR TITLE
Fix rounding of dims for zoom

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var getDimArray = function( dims, zoom ) {
 	var dimArr = typeof dims === 'string' ? dims.split(',') : dims;
 	zoom = zoom || 1;
 	return dimArr.map(function(v) {
-		return (Number(v) * zoom) || null;
+		return Math.round((Number(v) * zoom)) || null;
 	});
 }
 


### PR DESCRIPTION
I have an issue with Tachyon crashing. I have narrowed the issue down to using  resize and zoom param, in particular with values of zoom like `1.5` or `0.75` that lead to final dimensions which are not an integer.

My case: 
Original image fairly big: `3288×2055`
Requested size: `1200x825`
Zoom param: `1.5`.

Following some discussion with @roborourke on Slack, the fix is to round dimensions to an `int`.