### PR TITLE
Update to build with Node 8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 RUN apt-get update && apt-get install -y curl build-essential python2.7
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get -y install nodejs
 RUN ln -sf /usr/bin/python2.7 /usr/bin/python
 CMD cd /build ; npm install --production

--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -155,7 +155,7 @@
 					"S3Bucket": { "Ref" : "NodeTachyonBucket" },
 					"S3Key": { "Ref" : "NodeTachyonLambdaPath" }
 				},
-				"Runtime": "nodejs6.10",
+				"Runtime": "nodejs8.10",
 				"Timeout": "60",
 				"MemorySize": 256,
 				"Handler": "lambda-handler.handler",


### PR DESCRIPTION
In accordance with the AWS EOL policies, new Node 6.x Lambda instances can not be created after April 30, 2019. Updates to existing Node 6.x instances will be disabled 30 days later.

Tested on my website with Tachyon 2.1.7 and [it's working](https://peterwilson.cc/uploads/2016/12/IMG_0502.jpg?w=500&nc=0001).

Fixes #77 