### PR TITLE
Add basic support for robots.txt

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,8 +34,7 @@ http.createServer( function( request, response ) {
 
 	// robots.txt
 	if ( params.pathname === '/robots.txt' ) {
-		response.writeHead( 200 )
-		response.type('text/plain');
+		response.writeHead( 200 );
 		response.write( 'User-agent: *' + '\n' + 'Allow: /' )
 		return response.end()
 	}

--- a/server.js
+++ b/server.js
@@ -30,12 +30,12 @@ http.createServer( function( request, response ) {
 		response.writeHead( 200 )
 		response.write( 'All good.' )
 		return response.end()
-  }
+	}
 
 	// robots.txt
 	if ( params.pathname === '/robots.txt' ) {
-    response.writeHead( 200 )
-    response.type('text/plain');
+		response.writeHead( 200 )
+		response.type('text/plain');
 		response.write( 'User-agent: *' + '\n' + 'Allow: /' )
 		return response.end()
 	}

--- a/server.js
+++ b/server.js
@@ -35,7 +35,9 @@ http.createServer( function( request, response ) {
 
 	// robots.txt
 	if ( params.pathname === '/robots.txt' ) {
-		response.writeHead( 200 );
+		response.writeHead( 200, {
+			'Content-Type': 'text/plain'
+		} );
 		response.write( 'User-agent: *' + os.EOL + 'Allow: /' )
 		return response.end()
 	}

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ http.createServer( function( request, response ) {
 	if ( params.pathname === '/robots.txt' ) {
     response.writeHead( 200 )
     response.type('text/plain');
-		response.write( 'User-agent: *' + '\n' + 'Disallow: /' )
+		response.write( 'User-agent: *' + '\n' + 'Allow: /' )
 		return response.end()
 	}
 

--- a/server.js
+++ b/server.js
@@ -30,6 +30,13 @@ http.createServer( function( request, response ) {
 		response.writeHead( 200 )
 		response.write( 'All good.' )
 		return response.end()
+  }
+
+	// robots.txt
+	if ( params.pathname === '/robots.txt' ) {
+		response.writeHead( 200 )
+		response.write( 'User-agent: *' + '\n' + 'Disallow: /' )
+		return response.end()
 	}
 
 	return tachyon.s3( config, decodeURIComponent( params.pathname.substr(1) ), params.query, function( err, data, info ) {

--- a/server.js
+++ b/server.js
@@ -34,7 +34,8 @@ http.createServer( function( request, response ) {
 
 	// robots.txt
 	if ( params.pathname === '/robots.txt' ) {
-		response.writeHead( 200 )
+    response.writeHead( 200 )
+    response.type('text/plain');
 		response.write( 'User-agent: *' + '\n' + 'Disallow: /' )
 		return response.end()
 	}

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ var http   = require("http"),
 	url    = require("url"),
 	path   = require("path"),
 	fs     = require("fs"),
+	os     = require("os"),
 	tachyon= require( './index' ),
 	args = process.argv.slice(2),
 	port   = Number( args[0] ) ? args[0] : 8080,
@@ -35,7 +36,7 @@ http.createServer( function( request, response ) {
 	// robots.txt
 	if ( params.pathname === '/robots.txt' ) {
 		response.writeHead( 200 );
-		response.write( 'User-agent: *' + '\n' + 'Allow: /' )
+		response.write( 'User-agent: *' + os.EOL + 'Allow: /' )
 		return response.end()
 	}
 


### PR DESCRIPTION
This is to prevent issues where services, such as Twitter, aren't able to generate a card because `/robots.txt` is missing from Tachyon's domain.