### PR TITLE
Added binary media type to APIGW

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -1,5 +1,5 @@
 {
-	"Description": "Human Made Tachyon Image Server with Lambda v2.1.8",
+	"Description": "Human Made Tachyon Image Server with Lambda v2.1.9",
 	"Parameters": {
 		"NodeTachyonBucket" : {
 			"Type" : "String",
@@ -38,6 +38,7 @@
 			"Type": "AWS::ApiGateway::RestApi",
 			"Properties": {
 				"Name" : "Tachyon"
+				"BinaryMediaTypes" : "image~1*",
 			}
 		},
 		"ApiGatewayMethod": {


### PR DESCRIPTION
Looks like you can add Binary support via CloudFormation. 
This should work for new stack creations and will help if we need to create Tachyon in new regions.
`~1` is what's required for the forward slash.

However there is a known a bug if _updating_ the binary support details via CF stack as outlined in the AWS forum below.

Reference materials:
https://forums.aws.amazon.com/thread.jspa?messageID=797934
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-binarymediatypes
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html