### PR TITLE
Update sharp to 0.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 RUN apt-get update && apt-get install -y curl build-essential python2.7
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get -y install nodejs
 RUN ln -sf /usr/bin/python2.7 /usr/bin/python
 CMD cd /build ; npm install --production

--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -150,13 +150,12 @@
 		"LambdaFunction": {
 			"Type": "AWS::Lambda::Function",
 			"Properties": {
-				"Handler": "index.handler",
 				"Role": { "Fn::GetAtt" : [ "LambdaFunctionIAMRole", "Arn"] },
 				"Code": {
 					"S3Bucket": { "Ref" : "NodeTachyonBucket" },
 					"S3Key": { "Ref" : "NodeTachyonLambdaPath" }
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"Timeout": "60",
 				"MemorySize": 256,
 				"Handler": "lambda-handler.handler",

--- a/docs/server.md
+++ b/docs/server.md
@@ -48,7 +48,7 @@ Simply upload Tachyon to S3 per Step 1 above, then create a new Lambda function 
 
 ![](lambda-upload.png)
 
-Select Node 4.3 for the environment. Tachyon requires the S3 bucket and region to be configured as Environment Variables, with the keys `S3_BUCKET` and `S3_REGION` (these can be changed after creation if required).
+Select Node 10.x for the environment. Tachyon requires the S3 bucket and region to be configured as Environment Variables, with the keys `S3_BUCKET` and `S3_REGION` (these can be changed after creation if required).
 
 ![](lambda-env.png)
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports.s3 = function(config, key, args, callback) {
 	}
 	var s3 = regions[config.region];
 
-	return s3.makeRequest(
+	return s3.makeUnauthenticatedRequest(
 		'getObject',
 		{ Bucket: config.bucket, Key: key },
 		function(err, data) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports.s3 = function(config, key, args, callback) {
 	}
 	var s3 = regions[config.region];
 
-	return s3.makeUnauthenticatedRequest(
+	return s3.makeRequest(
 		'getObject',
 		{ Bucket: config.bucket, Key: key },
 		function(err, data) {
@@ -114,18 +114,7 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 
 					// resize
 					if (args.resize) {
-						args.resize = getDimArray( args.resize, zoom );
-
-						// apply cropping strategies
-						if ( args.gravity ) {
-							image.crop( args.gravity );
-						}
-						if ( args.crop_strategy === 'attention' ) {
-							image.crop( sharp.strategy.attention );
-						}
-						if ( args.crop_strategy === 'entropy' ) {
-							image.crop( sharp.strategy.entropy );
-						}
+						// apply smart crop if available
 						if ( args.crop_strategy === 'smart' && crop ) {
 							image.extract({
 								left: crop.x,
@@ -136,39 +125,39 @@ module.exports.resizeBuffer = function(buffer, args, callback) {
 						}
 
 						// apply the resize
-						image.resize.apply(
-							image,
-							args.resize
-						);
+						args.resize = getDimArray( args.resize, zoom );
+						image.resize({
+							width: args.resize[0],
+							height: args.resize[1],
+							withoutEnlargement: true,
+							position: ( args.crop_strategy !== 'smart' && args.crop_strategy ) || args.gravity || 'centre',
+						});
 					} else if (args.fit) {
 						args.fit = getDimArray( args.fit, zoom );
-						image.resize.apply(
-							image,
-							args.fit
-						);
-						image.max();
+						image.resize({
+							width: args.fit[0],
+							height: args.fit[1],
+							fit: 'inside',
+							withoutEnlargement: true,
+						});
 					} else if (args.lb) {
 						args.lb = getDimArray( args.lb, zoom );
-						image.resize.apply(
-							image,
-							args.lb
-						);
-
-						// default to a black background to replicate Photon API behaviour
-						// when no background colour specified
-						if (!args.background) {
-							args.background = 'black';
-						}
-						image.background(args.background);
-						image.embed();
+						image.resize({
+							width: args.lb[0],
+							height: args.lb[1],
+							fit: 'contain',
+							// default to a black background to replicate Photon API behaviour
+							// when no background colour specified
+							background: args.background || 'black',
+							withoutEnlargement: true,
+						});
 					} else if (args.w || args.h) {
-						image.resize(
-							(Number(args.w) * zoom) || null,
-							(Number(args.h) * zoom) || null
-						);
-						if (!args.crop) {
-							image.max();
-						}
+						image.resize({
+							width: (Number(args.w) * zoom) || null,
+							height: (Number( args.h ) * zoom) || null,
+							fit: args.crop ? 'cover' : 'inside',
+							withoutEnlargement: true,
+						});
 					}
 
 					// return a default compression value based on a logarithmic scale

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "license": "ISC",
   "dependencies": {
     "animated-gif-detector": "^1.2.0",
-    "sharp": "^0.17.0",
+    "sharp": "^0.23.0",
     "smartcrop-sharp": "^2.0.3"
   },
   "devDependencies": {
     "aws-sdk": "^2.276.1",
     "cli-table": "^0.3.1",
-    "filesize": "^3.5.10"
+    "filesize": "^4.1.2"
   }
 }

--- a/test-filesize/index.js
+++ b/test-filesize/index.js
@@ -44,7 +44,7 @@ async function test() {
 
 			// Save each one to the file system for viewing.
 			Object.entries(resized).forEach(([size, image]) => {
-				fs.writeFile( `${__dirname}/output/${imageName}-${size}.${image.info.format}`, image.data );
+				fs.writeFile( `${__dirname}/output/${imageName}-${size}.${image.info.format}`, image.data, () => {});
 			});
 
 			table.push([


### PR DESCRIPTION
This also recommends using node10.x which is now available on Lambda. It should work with node 8 however.

In addition this updates the use of `resize` to match the updated API and removes all deprecated function calls.

Lastly it was cheap to add the `withoutEnlargment` param to the resize operations to fix #75

Fixes #75
Fixes #81