### PR TITLE
Handle 404 errors

### DIFF
--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -18,6 +18,16 @@ exports.handler = function(event, context, callback) {
 		if (err) {
 			if (err.message === 'fallback-to-original') {
 				return proxyFile(region, bucket, key, callback);
+			} else if ( err.code === 'AccessDenied' ) {
+				// An AccessDenied error means the file is either protected, or doesn't exist.
+				// We don't get a NotFound error because Tachyon makes unauthenticated calls
+				// so S3.
+				var resp = {
+					statusCode: 404,
+					body: "File not found.",
+					isBase64Encoded: false,
+				};
+				return callback(null, resp);
 			}
 			return context.fail(err);
 		}


### PR DESCRIPTION
As described in the comment, 404 errors are shown as Access Denied, due to them being unauthenticated requests to S3.

Fixes #95.