### PR TITLE
Use build-lambdaci instead of own Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 ## Release Process
 
 1. Create and push a new tag following the convention `vx.x.x`
-1. Build a new ZIP file by running `npm run build-docker && npm run build-node-modules && npm run build-zip`
+1. Build a new ZIP file by running `npm run build-node-modules && npm run build-zip`
 1. Publish a new GitHub release, uploading `lambda.zip` as the built artifact to GitHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM ubuntu:trusty
-RUN apt-get update && apt-get install -y curl build-essential python2.7
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get update && apt-get -y install nodejs
-RUN ln -sf /usr/bin/python2.7 /usr/bin/python
-CMD cd /build ; npm install --production

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "function-name": ""
   },
   "scripts": {
-    "build-node-modules": "rm -R node_modules ; docker run --rm -v `pwd`:/var/task lambci/lambda:build-nodejs10.x npm instal",
+    "build-node-modules": "rm -R node_modules ; docker run --rm -v `pwd`:/var/task lambci/lambda:build-nodejs10.x npm install",
     "test-file": "docker run --rm -e S3_BUCKET=hmn-uploads-eu -e S3_REGION=eu-west-1 -v `pwd`:/var/task lambci/lambda:nodejs10.x lambda-handler.handler '{\"path\":\"/'$npm_config_path'\", \"headers\":{}}'",
     "build-zip": "zip -r lambda.zip ./node_modules/ index.js proxy-file.js lambda-handler.js",
     "upload-zip": "aws s3 --region=$npm_config_region cp ./lambda.zip s3://$npm_config_bucket/$npm_config_path",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "function-name": ""
   },
   "scripts": {
-    "build-docker": "docker build . -t tachyon-build",
-    "build-node-modules": "rm -R node_modules ; docker run -v `pwd`:/build -t tachyon-build",
+    "build-node-modules": "rm -R node_modules ; docker run --rm -v `pwd`:/var/task lambci/lambda:build-nodejs10.x npm instal",
+    "test-file": "docker run --rm -e S3_BUCKET=hmn-uploads-eu -e S3_REGION=eu-west-1 -v `pwd`:/var/task lambci/lambda:nodejs10.x lambda-handler.handler '{\"path\":\"/'$npm_config_path'\", \"headers\":{}}'",
     "build-zip": "zip -r lambda.zip ./node_modules/ index.js proxy-file.js lambda-handler.js",
     "upload-zip": "aws s3 --region=$npm_config_region cp ./lambda.zip s3://$npm_config_bucket/$npm_config_path",
     "update-function-code": "aws lambda update-function-code --region $npm_config_region --function-name $npm_config_function_name --zip-file fileb://`pwd`/lambda.zip"


### PR DESCRIPTION
This simplifies the building process and means it's much easier to update versions in the future.