### PR TITLE
Use env var to check if xray available

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,12 @@ var sharp = require('sharp'),
 	isAnimated = require('animated-gif-detector'),
 	smartcrop = require('smartcrop-sharp');
 
-var AWS = AWSXRay.captureAWS(require('aws-sdk'));
+let AWS;
+if ( process.env.AWS_XRAY_DAEMON_ADDRESS ) {
+	AWS = AWSXRay.captureAWS(require('aws-sdk'));
+} else {
+	AWS = require('aws-sdk');
+}
 
 var regions = {};
 


### PR DESCRIPTION
Because there's no execution context available locally or in docker for example we can check for an environment variable to determine whether to use the wrapper.