### PR TITLE
Fix tracking pngquant time in X-Ray

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,8 +207,8 @@ module.exports.resizeBuffer = async function(buffer, args, callback) {
 				if ( info.format === 'png' ) {
 
 					if ( enableTracing ) {
-						var segment = new AWSXRay.Segment( 'imagemin-pngquant' );
-						AWSXRay.setSegment( segment );
+						var mainSegment = AWSXRay.getSegment();
+						var segment = mainSegment.addNewSubsegment( 'imagemin-pngquant' );
 					}
 
 					data = await imageminPngquant()( data );


### PR DESCRIPTION
Turns out we were doing the tracking in X-Ray wrong, see https://github.com/aws/aws-xray-sdk-node/issues/148.