### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM lambci/lambda:nodejs10.x
+COPY node_modules/ /var/task/node_modules
+COPY server.js /var/task/
+COPY index.js /var/task
+
+ARG AWS_REGION
+ARG AWS_S3_BUCKET
+ARG AWS_S3_ENDPOINT
+ARG PORT
+
+# Start the reactor
+EXPOSE ${PORT:-8080}
+ENTRYPOINT /var/lang/bin/node server.js ${PORT:-8080}

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Build node_modules
+docker run --rm -v `pwd`:/var/task lambci/lambda:build-nodejs10.x npm install --production


### PR DESCRIPTION
Add a Dockerfile for running building a Tachyon docker image. This runs it in a very similar environment to Lambda.

@roborourke I'm thinking this could replace https://github.com/humanmade/tachyon-docker, as it's a lot simpler and also provides an environment much more similar to Lambda. There's some optimization we could do here still as it's copying all node_modules, but could exclude the AWS SDK as that's already in the base Lambda image.