### PR TITLE
Fix VipsJpeg error

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ const applyZoomCompression = function ( defaultValue, zoom ) {
 
 module.exports.resizeBuffer = async function(buffer, args, callback) {
 	try {
-		const image = sharp(buffer).withMetadata();
+		const image = sharp(buffer, {failOnError: false}).withMetadata();
 
 		// check we can get valid metadata
 		const metadata = await image.metadata();


### PR DESCRIPTION
Fix error "VipsJpeg: Invalid SOS parameters for sequential JPEG" that occurs in photos taken by some Samsung devices. See: https://github.com/lovell/sharp/issues/1578

Image that the error occurs:
https://placemobi.s3.amazonaws.com/img/uploads/2019/10/20191011_155740.jpg