### PR TITLE
Add support for forwarding Signed URLs

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -192,7 +192,7 @@
 							"Headers" : [ "X-WebP" ],
 							"QueryString" : "true"
 						},
-						"MinTTL" : 63115200,
+						"MinTTL" : 0,
 						"DefaultTTL": 63115201,
 						"MaxTTL": 63115202,
 						"TargetOriginId" : { "Ref" : "AWS::StackName" },
@@ -218,7 +218,7 @@
 								"Headers" : [ "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers" ]
 							},
 							"PathPattern" : "*.gif",
-							"MinTTL" : 63115200,
+							"MinTTL" : 0,
 							"DefaultTTL": 63115201,
 							"MaxTTL": 63115202,
 							"TargetOriginId" : "S3-Proxy",

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var sharp = require('sharp'),
 	isAnimated = require('animated-gif-detector'),
 	smartcrop = require('smartcrop-sharp'),
 	imageminPngquant = require('imagemin-pngquant'),
-	querystring = require("querystring");
+	querystring = require('querystring');
 
 const enableTracing = process.env.AWS_XRAY_DAEMON_ADDRESS;
 let AWS;
@@ -58,14 +58,14 @@ module.exports.s3 = function(config, key, args, callback) {
 			// Append the presigned URL params to the S3 file request URL.
 			request.addListener( 'build', function ( req ) {
 				const urlParams = presignedParams.reduce( ( params, urlParam ) => {
-					params[ urlParam ] = args[ urlParam ]
+					params[ urlParam ] = args[ urlParam ];
 					return params;
 				}, {} );
 				req.httpRequest.path += `?${ querystring.stringify( urlParams ) }`;
 			});
 		}
 	}
-	request.send( function( err, data ) {
+	request.send( function ( err, data ) {
 		if ( err ) {
 			return callback( err );
 		}

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports.s3 = function(config, key, args, callback) {
 			});
 		}
 	}
-	request.send( function(err, data) {
+	request.send( function( err, data ) {
 		if (err) {
 			return callback(err);
 		}

--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ module.exports.s3 = function(config, key, args, callback) {
 		}
 	}
 	request.send( function( err, data ) {
-		if (err) {
-			return callback(err);
+		if ( err ) {
+			return callback( err );
 		}
 
 		args.key = key;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var sharp = require('sharp'),
 	path = require('path'),
 	isAnimated = require('animated-gif-detector'),
 	smartcrop = require('smartcrop-sharp'),
-	imageminPngquant = require('imagemin-pngquant');
+	imageminPngquant = require('imagemin-pngquant'),
+	querystring = require("querystring");
 
 const enableTracing = process.env.AWS_XRAY_DAEMON_ADDRESS;
 let AWS;
@@ -33,22 +34,42 @@ module.exports.s3 = function(config, key, args, callback) {
 			Object.assign({ region: config.region }, s3config)
 		);
 	}
+
 	var s3 = regions[config.region];
-	var s3Request = authenticatedRequest ? s3.makeRequest : s3.makeUnauthenticatedRequest
+	var isPresigned = !! args['X-Amz-Algorithm'];
 
-	return s3Request(
-		'getObject',
-		{ Bucket: config.bucket, Key: key },
-		function(err, data) {
-			if (err) {
-				return callback(err);
-			}
-
-			args.key = key;
-
-			return module.exports.resizeBuffer(data.Body, args, callback);
+	if ( authenticatedRequest ) {
+		request = s3.makeRequest( 'getObject', { Bucket: config.bucket, Key: key } );
+	} else {
+		request = s3.makeUnauthenticatedRequest( 'getObject', { Bucket: config.bucket, Key: key } );
+		// To support forwarding presigned URLs, we hook into the post `build` step to add/forward
+		// the Amz signing URL query params from the current request.
+		if ( isPresigned ) {
+			request.addListener('build', function( req ) {
+				const params = querystring.stringify({
+					'X-Amz-Algorithm': args['X-Amz-Algorithm'],
+					'X-Amz-Content-Sha256': args['X-Amz-Content-Sha256'],
+					'X-Amz-Credential': args['X-Amz-Credential'],
+					'X-Amz-SignedHeaders': args['X-Amz-SignedHeaders'],
+					'X-Amz-Expires': args['X-Amz-Expires'],
+					'X-Amz-Signature': args['X-Amz-Signature'],
+					'X-Amz-Date': args['X-Amz-Date'],
+				});
+				req.httpRequest.path += `?${ params }`;
+			});
 		}
-	);
+	}
+	request.send( function(err, data) {
+		if (err) {
+			return callback(err);
+		}
+
+		args.key = key;
+
+		return module.exports.resizeBuffer(data.Body, args, callback);
+	} );
+
+	return request;
 };
 
 const getDimArray = function( dims, zoom ) {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports.s3 = function(config, key, args, callback) {
 
 		args.key = key;
 
-		return module.exports.resizeBuffer(data.Body, args, callback);
+		return module.exports.resizeBuffer( data.Body, args, callback );
 	} );
 
 	return request;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.s3 = function(config, key, args, callback) {
 		// To support forwarding presigned URLs, we hook into the post `build` step to add/forward
 		// the Amz signing URL query params from the current request.
 		if ( isPresigned ) {
-			request.addListener('build', function( req ) {
+			request.addListener( 'build', function ( req ) {
 				const params = querystring.stringify({
 					'X-Amz-Algorithm': args['X-Amz-Algorithm'],
 					'X-Amz-Content-Sha256': args['X-Amz-Content-Sha256'],

--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -36,7 +36,12 @@ exports.handler = function(event, context, callback) {
 		if ( args['X-Amz-Expires'] ) {
 			// Date format of X-Amz-Date is YYYYMMDDTHHMMSSZ, which is not parsable by Date.
 			const date = new Date( args['X-Amz-Date'].replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' ) );
+
+			// Calculate when the signed URL will expire, as we'll set the max-age
+			// cache control to this value.
 			const expires = ( date.getTime() / 1000 ) + Number( args['X-Amz-Expires'] );
+
+			// Mage age is the date the URL expires minus the current time.
 			maxAge = Math.round( expires - ( new Date().getTime() / 1000 ) );
 		}
 		var resp = {

--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -35,7 +35,8 @@ exports.handler = function(event, context, callback) {
 		let maxAge = 31536000;
 		if ( args['X-Amz-Expires'] ) {
 			// Date format of X-Amz-Date is YYYYMMDDTHHMMSSZ, which is not parsable by Date.
-			const date = new Date( args['X-Amz-Date'].replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' ) );
+			const dateString = args['X-Amz-Date'].replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' );
+			const date = new Date( dateString );
 
 			// Calculate when the signed URL will expire, as we'll set the max-age
 			// cache control to this value.

--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -35,7 +35,7 @@ exports.handler = function(event, context, callback) {
 		let maxAge = 31536000;
 		if ( args['X-Amz-Expires'] ) {
 			// Date format of X-Amz-Date is YYYYMMDDTHHMMSSZ, which is not parsable by Date.
-			const dateString = args['X-Amz-Date'].replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' );
+			const dateString = args['X-Amz-Date'].replace( /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' );
 			const date = new Date( dateString );
 
 			// Calculate when the signed URL will expire, as we'll set the max-age

--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -31,11 +31,19 @@ exports.handler = function(event, context, callback) {
 			}
 			return context.fail(err);
 		}
+		// If this is a signed URL, we need to calculate the max-age of the image.
+		let maxAge = 31536000;
+		if ( args['X-Amz-Expires'] ) {
+			// Date format of X-Amz-Date is YYYYMMDDTHHMMSSZ, which is not parsable by Date.
+			const date = new Date( args['X-Amz-Date'].replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, '$1-$2-$3T$4:$5:$6Z' ) );
+			const expires = ( date.getTime() / 1000 ) + Number( args['X-Amz-Expires'] );
+			maxAge = Math.round( expires - ( new Date().getTime() / 1000 ) );
+		}
 		var resp = {
 			statusCode: 200,
 			headers: {
 				'Content-Type': 'image/' + info.format,
-				'Cache-Control': 'max-age=31536000',
+				'Cache-Control': `max-age=${ maxAge }`,
 				'Last-Modified': (new Date()).toUTCString(),
 			},
 			body: new Buffer(data).toString('base64'),


### PR DESCRIPTION
In cases where you want to use Tachyon to serve private URLs that have been presigned, we can now forward the signed parameters in the URL. Presigned urls should be generated using the AWS SDK at the point of URL generation.