### PR TITLE
fix error when no headers present and new Buffer deprecated msg

### DIFF
--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -8,7 +8,7 @@ exports.handler = function(event, context, callback) {
 	key = key.replace( '/uploads/tachyon/', '/uploads/' );
 	var args = event.queryStringParameters || {};
 	if ( typeof args.webp === 'undefined' ) {
-		args.webp = !!event.headers['X-WebP'];
+		args.webp = !!(event.headers && event.headers['X-WebP']);
 	}
 	return tachyon.s3({ region: region, bucket: bucket }, key, args, function(
 		err,
@@ -52,7 +52,7 @@ exports.handler = function(event, context, callback) {
 				'Cache-Control': `max-age=${ maxAge }`,
 				'Last-Modified': (new Date()).toUTCString(),
 			},
-			body: new Buffer(data).toString('base64'),
+			body: Buffer.from(data).toString('base64'),
 			isBase64Encoded: true,
 		};
 		callback(null, resp);

--- a/proxy-file.js
+++ b/proxy-file.js
@@ -18,7 +18,7 @@ function sendOriginal(region, bucket, key, callback) {
 				headers: {
 					'Content-Type': data.ContentType,
 				},
-				body: new Buffer(data.Body).toString('base64'),
+				body: Buffer.from(data.Body).toString('base64'),
 				isBase64Encoded: true,
 			};
 


### PR DESCRIPTION
fixed error when no webp lambda exists, no headers are present
changed new Buffer to Buffer.from, to address deprecation message