### PR TITLE
Fix syntax error in BinaryMediaTypes

### DIFF
--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -62,6 +62,7 @@
 				"Integration": {
 					"Type": "AWS_PROXY",
 					"IntegrationHttpMethod": "POST",
+					"ContentHandling": "CONVERT_TO_BINARY",
 					"Uri": { "Fn::Sub":"arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaFunction.Arn}/invocations"}
 				}
 			}

--- a/cloudformation-template.json
+++ b/cloudformation-template.json
@@ -49,7 +49,7 @@
 			"Type": "AWS::ApiGateway::RestApi",
 			"Properties": {
 				"Name" : "Tachyon",
-				"BinaryMediaTypes": [ "image~1*" ]
+				"BinaryMediaTypes": [ "image/*" ]
 			}
 		},
 		"ApiGatewayMethod": {


### PR DESCRIPTION
This accidentally had JSON Patch/JSON Path escaping, which is only needed in PATCH requests.

Fixes #114.