### PR TITLE
make tachyon compatible with lambda edge

### DIFF
--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -1,9 +1,19 @@
 var tachyon = require('./index');
 var proxyFile = require('./proxy-file');
+const querystring = require('querystring');
 
 exports.handler = function(event, context, callback) {
 	var region = process.env.S3_REGION;
 	var bucket = process.env.S3_BUCKET;
+
+	// adapt request for lambda edge, if no event.path
+	if (!event.path && event.Records && event.Records.length > 0) {
+		let request = event.Records[0].cf.request;
+		event.headers = request.headers;
+		event.path = request.uri;
+		event.queryStringParameters = querystring.parse(request.querystring);
+	}
+
 	var key = decodeURIComponent(event.path.substring(1));
 	key = key.replace( '/uploads/tachyon/', '/uploads/' );
 	var args = event.queryStringParameters || {};


### PR DESCRIPTION
This is actually a very small change that makes tachyon compatible with the lambda edge architecture.
The use case is to be able to use it in an architecture similar to that of the tachyon-edge project (without the cache step).
Basically it adapts the request to assume lambda edge, if no event.path exists.
Just add the lambda function (zip), configure three environment variables below and you are done.
- S3_AUTHENTICATED_REQUEST: true
- S3_BUCKET: your-bucket
- S3_REGION: us-east-1