### PR TITLE
enable tachyon setup as lambda for cloudfront origin request / response (no api gateway)

### DIFF
--- a/lambda-config.json
+++ b/lambda-config.json
@@ -1,0 +1,6 @@
+{
+	"S3_REGION": "us-east-1",
+    "S3_BUCKET": "your-s3-bucket",
+    "S3_AUTHENTICATED_REQUEST": "true",
+    "AWS_XRAY_DAEMON_ADDRESS": null
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build-node-modules": "rm -R node_modules ; docker run --rm -v `pwd`:/var/task lambci/lambda:build-nodejs10.x npm install",
     "test-file": "docker run --rm -e S3_BUCKET=hmn-uploads-eu -e S3_REGION=eu-west-1 -v `pwd`:/var/task lambci/lambda:nodejs10.x lambda-handler.handler '{\"path\":\"/'$npm_config_path'\", \"headers\":{}}'",
-    "build-zip": "rm lambda.zip; zip -r --exclude='node_modules/aws-sdk/*' --exclude='node_modules/animated-gif-detector/test/*' lambda.zip ./node_modules/ index.js proxy-file.js lambda-handler.js",
+    "build-zip": "rm lambda.zip; zip -r --exclude='node_modules/aws-sdk/*' --exclude='node_modules/animated-gif-detector/test/*' lambda.zip ./node_modules/ index.js proxy-file.js lambda-handler.js lambda-config.json",
     "upload-zip": "aws s3 --region=$npm_config_region cp ./lambda.zip s3://$npm_config_bucket/$npm_config_path",
     "update-function-code": "aws lambda update-function-code --region $npm_config_region --function-name $npm_config_function_name --zip-file fileb://`pwd`/lambda.zip"
   },


### PR DESCRIPTION
This PR makes tachyon compatible with the cloudfront origin request / response formats and lambda edge architecture.
The use case is to be able to use it in an architecture similar to that of the tachyon-edge project (without the cache step).

Basically it adapts the request to assume lambda edge, if there are no environment variables configured.
Edit lambda-config.json inside the lambda.zip, and you are done.
Manual setup is well described in the tachyon-edge project. 
I will later try to add some docs for this setup.

Why not use tachyon-edge? It has had no support for 2 years. 
A lot has changed, including some significant changes in the sharp module.

Just finalized the tests and it works fine.