### PR TITLE
143: Fix issue when specifying a false condition for using webp

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,6 +46,9 @@ http.createServer( function( request, response ) {
 	const args = params.query || {};
 	if ( typeof args.webp === 'undefined' ) {
 		args.webp = !!( request.headers && request.headers['accept'] && request.headers['accept'].match( 'image/webp' ) );
+	} else {
+		// args.webp will always be a string at this point, so lets convert it to a boolean to not break future conditionals.
+		args.webp = (args.webp == true);
 	}
 
 	return tachyon.s3( config, key, args, function( err, data, info ) {


### PR DESCRIPTION
`args.webp` is a string by default, so using a conditional with a string in it will always be true unless it is an empty string. This gives a very odd results to have to use `webp=` in order to force using a jpeg. Converting the parameter to a boolean fixes potential issues where future conditionals are just using `(args.webp)` where any string > 0 characters, is equal to true. In addition a conditional which doesn’t consider the datatype allows most strings to be false and `1` to be true as defined in the docs.