### PR TITLE
Allow a case-insensitive X-WebP header

### DIFF
--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -8,7 +8,7 @@ exports.handler = function(event, context, callback) {
 	key = key.replace( '/uploads/tachyon/', '/uploads/' );
 	var args = event.queryStringParameters || {};
 	if ( typeof args.webp === 'undefined' ) {
-		args.webp = !!(event.headers && event.headers['X-WebP']);
+		args.webp = !!(event.headers && Object.keys(event.headers).find(key => key.toLowerCase() == 'x-webp'));
 	}
 	return tachyon.s3({ region: region, bucket: bucket }, key, args, function(
 		err,


### PR DESCRIPTION
Looking to use CloudFront Functions for WebP detection, which has rules on capitilizing headers (no way to capitalize the P in X-Webp). This changes makes the search for the header case insensitive.