### PR TITLE
Support alternative method of passing Presigned params

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 18.x
       - run: env
       - run: npm install
-      - run: npm run test
+      - run: npx jest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          S3_BUCKET: ${{ env.S3_BUCKET }}
-          S3_REGION: ${{ env.S3_REGION }}
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_REGION: ${{ vars.S3_REGION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET: ${{ env.S3_BUCKET }}
+          S3_REGION: ${{ env.S3_REGION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - run: env
       - run: npm install
       - run: npx jest
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+      - run: env
       - run: npm install
       - run: npm run test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,7 @@ jobs:
           node-version: 18.x
       - run: npm install
       - run: npm run test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -10,5 +10,12 @@ declare var awslambda: {
 	streamifyResponse: (
 		handler: StreamifyHandler
 	) => ( event: APIGatewayProxyEventV2, context: ResponseStream ) => void,
+	HttpResponseStream: {
+		from( response: ResponseStream, metadata: {
+			headers?: Record<string, string>,
+			statusCode?: number,
+			cookies?: string[],
+		} ): ResponseStream
+	}
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"smartcrop-sharp": "^2.0.6"
 			},
 			"devDependencies": {
+				"@aws-sdk/s3-request-presigner": "^3.523.0",
 				"@humanmade/eslint-config": "^1.1.3",
 				"@types/aws-lambda": "^8.10.119",
 				"@types/cli-table": "^0.3.4",
@@ -653,6 +654,87 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/s3-request-presigner": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.523.0.tgz",
+			"integrity": "sha512-BBq4b7Rc0DQzi1q3hZuQ/uOAexwIxDw3CFZ7z6BAIlHt09wriJn6qSBExPGuKSBsu+DkJfeNq6RXImggOSthJg==",
+			"dev": true,
+			"dependencies": {
+				"@aws-sdk/signature-v4-multi-region": "3.523.0",
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-format-url": "3.523.0",
+				"@smithy/middleware-endpoint": "^2.4.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.1",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.523.0.tgz",
+			"integrity": "sha512-cCZ3+XcAJMSC2rsw5F2h+ILVgjijRTxgzD6l7vExhc7UUOOPxXa6R9oGV3+6ANQ/P0w8rvE78j8UAMzlpq+cZA==",
+			"dev": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-arn-parser": "3.495.0",
+				"@smithy/node-config-provider": "^2.2.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/signature-v4": "^2.1.3",
+				"@smithy/smithy-client": "^2.4.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.523.0.tgz",
+			"integrity": "sha512-TU1AfF6YlihdMy4H5YtkmFYmA/Zrh7sqk2V6tPiR2Vu6idc+9xm1R0UE/2V/DKgMIkxfr4+cAojtp2kqYuuF/A==",
+			"dev": true,
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "3.523.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/signature-v4": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+			"integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+			"dev": true,
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.495.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.495.0.tgz",
+			"integrity": "sha512-hwdA3XAippSEUxs7jpznwD63YYFR+LtQvlEcebPTgWR9oQgG9TfS+39PUfbnEeje1ICuOrN3lrFqFbmP9uzbMg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
 			"version": "3.451.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.451.0.tgz",
@@ -745,6 +827,34 @@
 			"dependencies": {
 				"@aws-sdk/types": "3.451.0",
 				"@smithy/util-endpoints": "^1.0.4",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.523.0.tgz",
+			"integrity": "sha512-OWi+8bsEfxG4DvHkWauxyWVZMbYrezC49DbGDEu1lJgk9eqQALlyGkZHt9O8KKfyT/mdqQbR8qbpkxqYcGuHVA==",
+			"dev": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/querystring-builder": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+			"integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+			"dev": true,
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3713,11 +3823,11 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.13.tgz",
-			"integrity": "sha512-eeOPD+GF9BzF/Mjy3PICLePx4l0f3rG/nQegQHRLTloN5p1lSJJNZsyn+FzDnW8P2AduragZqJdtKNCxXozB1Q==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
+			"integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3772,13 +3882,13 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.13.tgz",
-			"integrity": "sha512-CExbelIYp+DxAHG8RIs0l9QL7ElqhG4ym9BNoSpkPa4ptBQfzJdep3LbOSVJIE2VUdBAeObdeL6EDB3Jo85n3g==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+			"integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
 			"dependencies": {
 				"@aws-crypto/crc32": "3.0.0",
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -3834,14 +3944,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.6.tgz",
-			"integrity": "sha512-PStY3XO1Ksjwn3wMKye5U6m6zxXpXrXZYqLy/IeCbh3nM9QB3Jgw/B0PUSLUWKdXg4U8qgEu300e3ZoBvZLsDg==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
+			"integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
 			"dependencies": {
-				"@smithy/protocol-http": "^3.0.9",
-				"@smithy/querystring-builder": "^2.0.13",
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-base64": "^2.0.1",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/querystring-builder": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-base64": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -3893,9 +4003,9 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+			"integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -3927,16 +4037,16 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.0.tgz",
-			"integrity": "sha512-tddRmaig5URk2106PVMiNX6mc5BnKIKajHHDxb7K0J5MLdcuQluHMGnjkv18iY9s9O0tF+gAcPd/pDXA5L9DZw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
+			"integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
 			"dependencies": {
-				"@smithy/middleware-serde": "^2.0.13",
-				"@smithy/node-config-provider": "^2.1.5",
-				"@smithy/shared-ini-file-loader": "^2.2.4",
-				"@smithy/types": "^2.5.0",
-				"@smithy/url-parser": "^2.0.13",
-				"@smithy/util-middleware": "^2.0.6",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/shared-ini-file-loader": "^2.3.4",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-middleware": "^2.1.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3962,11 +4072,11 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.13.tgz",
-			"integrity": "sha512-tBGbeXw+XsE6pPr4UaXOh+UIcXARZeiA8bKJWxk2IjJcD1icVLhBSUQH9myCIZLNNzJIH36SDjUX8Wqk4xJCJg==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
+			"integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3974,11 +4084,11 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.7.tgz",
-			"integrity": "sha512-L1KLAAWkXbGx1t2jjCI/mDJ2dDNq+rp4/ifr/HcC6FHngxho5O7A5bQLpKHGlkfATH6fUnOEx0VICEVFA4sUzw==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
+			"integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3986,13 +4096,13 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.5.tgz",
-			"integrity": "sha512-3Omb5/h4tOCuKRx4p4pkYTvEYRCYoKk52bOYbKUyz/G/8gERbagsN8jFm4FjQubkrcIqQEghTpQaUw6uk+0edw==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
+			"integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
 			"dependencies": {
-				"@smithy/property-provider": "^2.0.14",
-				"@smithy/shared-ini-file-loader": "^2.2.4",
-				"@smithy/types": "^2.5.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.4",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4000,14 +4110,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "2.1.9",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.9.tgz",
-			"integrity": "sha512-+K0q3SlNcocmo9OZj+fz67gY4lwhOCvIJxVbo/xH+hfWObvaxrMTx7JEzzXcluK0thnnLz++K3Qe7Z/8MDUreA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
+			"integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
 			"dependencies": {
-				"@smithy/abort-controller": "^2.0.13",
-				"@smithy/protocol-http": "^3.0.9",
-				"@smithy/querystring-builder": "^2.0.13",
-				"@smithy/types": "^2.5.0",
+				"@smithy/abort-controller": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/querystring-builder": "^2.1.3",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4015,11 +4125,11 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.14.tgz",
-			"integrity": "sha512-k3D2qp9o6imTrLaXRj6GdLYEJr1sXqS99nLhzq8fYmJjSVOeMg/G+1KVAAc7Oxpu71rlZ2f8SSZxcSxkevuR0A==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+			"integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4027,11 +4137,11 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.9.tgz",
-			"integrity": "sha512-U1wl+FhYu4/BC+rjwh1lg2gcJChQhytiNQSggREgQ9G2FzmoK9sACBZvx7thyWMvRyHQTE22mO2d5UM8gMKDBg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+			"integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4039,12 +4149,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.13.tgz",
-			"integrity": "sha512-JhXKwp3JtsFUe96XLHy/nUPEbaXqn6r7xE4sNaH8bxEyytE5q1fwt0ew/Ke6+vIC7gP87HCHgQpJHg1X1jN2Fw==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
+			"integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-uri-escape": "^2.0.0",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-uri-escape": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4052,11 +4162,11 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.13.tgz",
-			"integrity": "sha512-TEiT6o8CPZVxJ44Rly/rrsATTQsE+b/nyBVzsYn2sa75xAaZcurNxsFd8z1haoUysONiyex24JMHoJY6iCfLdA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
+			"integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4075,11 +4185,11 @@
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.4.tgz",
-			"integrity": "sha512-9dRknGgvYlRIsoTcmMJXuoR/3ekhGwhRq4un3ns2/byre4Ql5hyUN4iS0x8eITohjU90YOnUCsbRwZRvCkbRfw==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
+			"integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4087,17 +4197,17 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.15.tgz",
-			"integrity": "sha512-SRTEJSEhQYVlBKIIdZ9SZpqW+KFqxqcNnEcBX+8xkDdWx+DItme9VcCDkdN32yTIrICC+irUufnUdV7mmHPjoA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+			"integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^2.0.13",
-				"@smithy/is-array-buffer": "^2.0.0",
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.6",
-				"@smithy/util-uri-escape": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.2",
+				"@smithy/eventstream-codec": "^2.1.3",
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-uri-escape": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4105,13 +4215,15 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "2.1.15",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.15.tgz",
-			"integrity": "sha512-rngZcQu7Jvs9UbHihK1EI67RMPuzkc3CJmu4MBgB7D7yBnMGuFR86tq5rqHfL2gAkNnMelBN/8kzQVvZjNKefQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
+			"integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
 			"dependencies": {
-				"@smithy/middleware-stack": "^2.0.7",
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-stream": "^2.0.20",
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-stream": "^2.1.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4119,9 +4231,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.5.0.tgz",
-			"integrity": "sha512-/a31lYofrMBkJb3BuPlYJTMKDj0hUmKUP6JFZQu6YVuQVoAjubiY0A52U9S0Uysd33n/djexCUSNJ+G9bf3/aA==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+			"integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -4130,21 +4242,21 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.13.tgz",
-			"integrity": "sha512-okWx2P/d9jcTsZWTVNnRMpFOE7fMkzloSFyM53fA7nLKJQObxM2T4JlZ5KitKKuXq7pxon9J6SF2kCwtdflIrA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
+			"integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
 			"dependencies": {
-				"@smithy/querystring-parser": "^2.0.13",
-				"@smithy/types": "^2.5.0",
+				"@smithy/querystring-parser": "^2.1.3",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-			"integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+			"integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4171,11 +4283,11 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+			"integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^2.0.0",
+				"@smithy/is-array-buffer": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4183,9 +4295,9 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-			"integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+			"integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -4239,9 +4351,9 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+			"integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -4250,11 +4362,11 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.6.tgz",
-			"integrity": "sha512-7W4uuwBvSLgKoLC1x4LfeArCVcbuHdtVaC4g30kKsD1erfICyQ45+tFhhs/dZNeQg+w392fhunCm/+oCcb6BSA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+			"integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
 			"dependencies": {
-				"@smithy/types": "^2.5.0",
+				"@smithy/types": "^2.10.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4275,17 +4387,17 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.20.tgz",
-			"integrity": "sha512-tT8VASuD8jJu0yjHEMTCPt1o5E3FVzgdsxK6FQLAjXKqVv5V8InCnc0EOsYrijgspbfDqdAJg7r0o2sySfcHVg==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
+			"integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^2.2.6",
-				"@smithy/node-http-handler": "^2.1.9",
-				"@smithy/types": "^2.5.0",
-				"@smithy/util-base64": "^2.0.1",
-				"@smithy/util-buffer-from": "^2.0.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.2",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -4293,9 +4405,9 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+			"integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -4304,11 +4416,11 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-			"integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+			"integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "sam build -u",
 		"start": "tsc -w & nodemon --watch dist/lambda-handler.js --exec 'node dist/lambda-handler.js'",
-		"test": "jest",
+		"test": "AWS_PROFILE=hmn-test S3_BUCKET=testtachyonbucket S3_REGION=us-east-1 jest",
 		"build-zip": "rm lambda.zip ; cd .aws-sam/build/Tachyon && zip -r --exclude='node_modules/animated-gif-detector/test/*' ../../../lambda.zip ./node_modules/ package.json ./dist/",
 		"upload-zip": "aws s3 --region=$npm_config_region cp ./lambda.zip s3://$npm_config_bucket/$npm_config_path",
 		"update-function-code": "aws lambda update-function-code --region $npm_config_region --function-name $npm_config_function_name --zip-file fileb://`pwd`/lambda.zip",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"smartcrop-sharp": "^2.0.6"
 	},
 	"devDependencies": {
+		"@aws-sdk/s3-request-presigner": "^3.523.0",
 		"@humanmade/eslint-config": "^1.1.3",
 		"@types/aws-lambda": "^8.10.119",
 		"@types/cli-table": "^0.3.4",

--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -1,5 +1,4 @@
 import { Args, getS3File, resizeBuffer, Config } from './lib';
-
 /**
  *
  * @param event

--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -23,11 +23,22 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 	const key = decodeURIComponent( event.rawPath.substring( 1 ) ).replace( '/tachyon/', '/' );
 	const args = ( event.queryStringParameters || {} ) as unknown as Args & {
 		'X-Amz-Expires'?: string;
+		'presign'?: string,
 		key: string;
 	};
 	args.key = key;
 	if ( typeof args.webp === 'undefined' ) {
 		args.webp = !! ( event.headers && Object.keys( event.headers ).find( key => key.toLowerCase() === 'x-webp' ) );
+	}
+
+	// If there is a presign param, we need to decode it and add it to the args. This is to provide a secondary way to pass pre-sign params,
+	// as using them in a Lambda function URL invocation will trigger a Lambda error.
+	if ( args.presign ) {
+		const presignArgs = new URLSearchParams( decodeURIComponent( args.presign ) );
+		for ( const [ key, value ] of presignArgs.entries() ) {
+			args[ key as keyof Args ] = value;
+		}
+		delete args.presign;
 	}
 
 	let s3_response = await getS3File( config, key, args );
@@ -55,6 +66,14 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 		maxAge = Math.round( expires - new Date().getTime() / 1000 ); // eslint-disable-line no-unused-vars
 	}
 
+	// Somewhat undocumented API on how to pass headers to a stream response.
+	response = awslambda.HttpResponseStream.from( response, {
+		headers: {
+			'Cache-Control': `max-age=${ maxAge }`,
+			'Last-Modified': ( new Date() ).toUTCString(),
+		},
+	} );
+
 	response.setContentType( 'image/' + info.format );
 	response.write( data );
 	response.end();
@@ -68,6 +87,18 @@ if ( typeof awslambda === 'undefined' ) {
 		 */
 		streamifyResponse( handler: StreamifyHandler ): StreamifyHandler {
 			return handler;
+		},
+		HttpResponseStream: {
+			/**
+			 * @param response The response stream object
+			 * @param metadata The metadata object
+			 * @param metadata.headers
+			 */
+			from( response: ResponseStream, metadata: {
+				headers?: Record<string, string>,
+			} ): ResponseStream {
+				return response;
+			},
 		},
 	};
 }

--- a/tests/test-lambda.ts
+++ b/tests/test-lambda.ts
@@ -58,4 +58,13 @@ global.awslambda = {
 	streamifyResponse( handler: StreamifyHandler ): StreamifyHandler {
 		return handler;
 	},
+	HttpResponseStream: {
+		/**
+		 * @param stream
+		 * @param metadata
+		 */
+		from( stream: ResponseStream, metadata ) : ResponseStream {
+			return stream;
+		},
+	},
 };

--- a/tests/test-lambda.ts
+++ b/tests/test-lambda.ts
@@ -60,8 +60,8 @@ global.awslambda = {
 	},
 	HttpResponseStream: {
 		/**
-		 * @param stream
-		 * @param metadata
+		 * @param stream The response stream.
+		 * @param metadata The metadata for the response.
 		 */
 		from( stream: ResponseStream, metadata ) : ResponseStream {
 			return stream;

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@jest/globals';
+
+import { handler } from '../src/lambda-handler';
+
+test( 'Test get private upload', async () => {
+	process.env.S3_BUCKET = 'hmn-uploads';
+	process.env.S3_REGION = 'us-east-1';
+
+	// The below credentials are temporary and will need regenerating before the test is run.
+	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
+	const event = {
+		'version': '2.0',
+		'routeKey': '$default',
+		'rawPath': '/s3-uploads-unit-tests/private.png',
+		'headers': {
+		},
+		'queryStringParameters': {
+			'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+			'X-Amz-Credential': 'AKIAYM4GX6NWUGJQMRZ4/20240227/us-east-1/s3/aws4_request',
+			'X-Amz-Date': '20240227T142125Z',
+			'X-Amz-Expires': '3600',
+			'X-Amz-SignedHeaders': 'host',
+			'X-Amz-Signature': '1eb6c4654f06256080544688a3124e4933050a070aced3db0e1830285726956c',
+		},
+		'isBase64Encoded': false,
+	};
+
+	let contentType;
+
+	await handler( event, {
+		/**
+		 * Set the content type for the respone.
+		 */
+		setContentType( type: string ): void {
+			contentType = type;
+		},
+		/**
+		 * Write data to the response.
+		 */
+		write( stream: string | Buffer ): void {
+			console.log( stream );
+		},
+		/**
+		 * End the response.
+		 */
+		end(): void {
+			console.log( 'end' );
+		},
+	} );
+
+	expect( contentType ).toBe( 'image/png' );
+} );
+
+test( 'Test get private upload with presign params', async () => {
+	process.env.S3_BUCKET = 'hmn-uploads';
+	process.env.S3_REGION = 'us-east-1';
+
+	// The below credentials are temporary and will need regenerating before the test is run.
+	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
+	const event = {
+		'version': '2.0',
+		'routeKey': '$default',
+		'rawPath': '/s3-uploads-unit-tests/private.png',
+		'headers': {
+		},
+		'queryStringParameters': {
+			presign: 'X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIAYM4GX6NWUGJQMRZ4%252F20240228%252Fus-east-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20240228T084322Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D829aa1a8b6b3e93ce666e1ddababcbbc8c6e6b4ac0a979da2fae4e360026c856',
+		},
+		'isBase64Encoded': false,
+	};
+
+	let contentType;
+
+	await handler( event, {
+		/**
+		 * Set the content type for the respone.
+		 */
+		setContentType( type: string ): void {
+			contentType = type;
+		},
+		/**
+		 * Write data to the response.
+		 */
+		write( stream: string | Buffer ): void {
+		},
+		/**
+		 * End the response.
+		 */
+		end(): void {
+		},
+	} );
+
+	expect( contentType ).toBe( 'image/png' );
+} );

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -90,11 +90,11 @@ test( 'Test get private upload with presign params', async () => {
 	const presignParams = await getPresignedUrlParams( 'private.png' ) as Record<string, string>;
 
 	// The below credentials are temporary and will need regenerating before the test is run.
-	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
+	// Run aws s3 presign --expires 3600 s3://hmn-uploads/private.png
 	const event = {
 		'version': '2.0',
 		'routeKey': '$default',
-		'rawPath': '/s3-uploads-unit-tests/private.png',
+		'rawPath': '/private.png',
 		'headers': {
 		},
 		'queryStringParameters': {

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -1,27 +1,67 @@
+import { GetObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { test, expect } from '@jest/globals';
+import { MiddlewareType } from '@smithy/types';
 
 import { handler } from '../src/lambda-handler';
+import { Args } from '../src/lib';
+
+/**
+ * Presign a URL for a given key.
+ * @param key
+ * @returns {Promise<string>}
+ */
+async function getPresignedUrlParams( key: string ) : Promise<Args> {
+	const client = new S3Client(
+		{
+			region: process.env.S3_REGION,
+			bucket: process.env.S3_BUCKET,
+		} as S3ClientConfig
+	);
+	const command = new GetObjectCommand( {
+		Bucket: process.env.S3_BUCKET,
+		Key: key,
+	} );
+
+	/**
+	 * Middleware to remove the x-id query string param form the GetObject call.
+	 */
+	const middleware: MiddlewareType<any, any> = ( next: any, context: any ) => async ( args: any ) => {
+		const { request } = args;
+		delete request.query['x-id'];
+		return next( args );
+	};
+
+	client.middlewareStack.addRelativeTo( middleware, {
+		name: 'tests',
+		relation: 'before',
+		toMiddleware: 'awsAuthMiddleware',
+		override: true,
+	} );
+
+	const presignedUrl = new URL( await getSignedUrl( client, command, {
+		expiresIn: 60,
+	} ) );
+	// console.log( presignedUrl );
+	let queryStringParameters: Args = {};
+	presignedUrl.searchParams.forEach( ( value, key ) => {
+		queryStringParameters[ key as keyof Args ] = value;
+	} );
+
+	return queryStringParameters;
+}
 
 test( 'Test get private upload', async () => {
 	process.env.S3_BUCKET = 'hmn-uploads';
 	process.env.S3_REGION = 'us-east-1';
 
-	// The below credentials are temporary and will need regenerating before the test is run.
-	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
 	const event = {
 		'version': '2.0',
 		'routeKey': '$default',
 		'rawPath': '/s3-uploads-unit-tests/private.png',
 		'headers': {
 		},
-		'queryStringParameters': {
-			'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-			'X-Amz-Credential': 'AKIAYM4GX6NWUGJQMRZ4/20240227/us-east-1/s3/aws4_request',
-			'X-Amz-Date': '20240227T142125Z',
-			'X-Amz-Expires': '3600',
-			'X-Amz-SignedHeaders': 'host',
-			'X-Amz-Signature': '1eb6c4654f06256080544688a3124e4933050a070aced3db0e1830285726956c',
-		},
+		queryStringParameters: await getPresignedUrlParams( 's3-uploads-unit-tests/private.png' ),
 		'isBase64Encoded': false,
 	};
 
@@ -55,6 +95,8 @@ test( 'Test get private upload with presign params', async () => {
 	process.env.S3_BUCKET = 'hmn-uploads';
 	process.env.S3_REGION = 'us-east-1';
 
+	const presignParams = await getPresignedUrlParams( 's3-uploads-unit-tests/private.png' ) as Record<string, string>;
+	// console.log( presignParams );
 	// The below credentials are temporary and will need regenerating before the test is run.
 	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
 	const event = {
@@ -64,7 +106,7 @@ test( 'Test get private upload with presign params', async () => {
 		'headers': {
 		},
 		'queryStringParameters': {
-			presign: 'X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIAYM4GX6NWUGJQMRZ4%252F20240228%252Fus-east-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20240228T084322Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D829aa1a8b6b3e93ce666e1ddababcbbc8c6e6b4ac0a979da2fae4e360026c856',
+			presign: encodeURIComponent( new URLSearchParams( presignParams ).toString() ),
 		},
 		'isBase64Encoded': false,
 	};

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -40,10 +40,7 @@ async function getPresignedUrlParams( key: string ) : Promise<Args> {
 		expiresIn: 60,
 	} ) );
 
-	let queryStringParameters: Args = {};
-	presignedUrl.searchParams.forEach( ( value, key ) => {
-		queryStringParameters[ key as keyof Args ] = value;
-	} );
+	const queryStringParameters: Args = Object.fromEntries( presignedUrl.searchParams.entries() );
 
 	return queryStringParameters;
 }

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { test, expect } from '@jest/globals';
 import { MiddlewareType } from '@smithy/types';
@@ -9,15 +9,12 @@ import { Args } from '../src/lib';
 /**
  * Presign a URL for a given key.
  * @param key
- * @returns {Promise<string>}
+ * @returns {Promise<Args>} The presigned params
  */
 async function getPresignedUrlParams( key: string ) : Promise<Args> {
-	const client = new S3Client(
-		{
-			region: process.env.S3_REGION,
-			bucket: process.env.S3_BUCKET,
-		} as S3ClientConfig
-	);
+	const client = new S3Client( {
+		region: process.env.S3_REGION,
+	} );
 	const command = new GetObjectCommand( {
 		Bucket: process.env.S3_BUCKET,
 		Key: key,
@@ -42,7 +39,7 @@ async function getPresignedUrlParams( key: string ) : Promise<Args> {
 	const presignedUrl = new URL( await getSignedUrl( client, command, {
 		expiresIn: 60,
 	} ) );
-	// console.log( presignedUrl );
+
 	let queryStringParameters: Args = {};
 	presignedUrl.searchParams.forEach( ( value, key ) => {
 		queryStringParameters[ key as keyof Args ] = value;

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -52,16 +52,13 @@ async function getPresignedUrlParams( key: string ) : Promise<Args> {
 }
 
 test( 'Test get private upload', async () => {
-	process.env.S3_BUCKET = 'hmn-uploads';
-	process.env.S3_REGION = 'us-east-1';
-
 	const event = {
 		'version': '2.0',
 		'routeKey': '$default',
-		'rawPath': '/s3-uploads-unit-tests/private.png',
+		'rawPath': '/private.png',
 		'headers': {
 		},
-		queryStringParameters: await getPresignedUrlParams( 's3-uploads-unit-tests/private.png' ),
+		queryStringParameters: await getPresignedUrlParams( 'private.png' ),
 		'isBase64Encoded': false,
 	};
 
@@ -78,13 +75,11 @@ test( 'Test get private upload', async () => {
 		 * Write data to the response.
 		 */
 		write( stream: string | Buffer ): void {
-			console.log( stream );
 		},
 		/**
 		 * End the response.
 		 */
 		end(): void {
-			console.log( 'end' );
 		},
 	} );
 
@@ -92,11 +87,8 @@ test( 'Test get private upload', async () => {
 } );
 
 test( 'Test get private upload with presign params', async () => {
-	process.env.S3_BUCKET = 'hmn-uploads';
-	process.env.S3_REGION = 'us-east-1';
+	const presignParams = await getPresignedUrlParams( 'private.png' ) as Record<string, string>;
 
-	const presignParams = await getPresignedUrlParams( 's3-uploads-unit-tests/private.png' ) as Record<string, string>;
-	// console.log( presignParams );
 	// The below credentials are temporary and will need regenerating before the test is run.
 	// Run aws s3 presign --expires 3600 s3://hmn-uploads/s3-uploads-unit-tests/private.png
 	const event = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
 		"resolveJsonModule": true,
 	},
 	"exclude": ["node_modules"],
-	"include": ["./src/**/*.ts", "./*.d.ts"],
+	"include": ["./src/**/*.ts", "./*.d.ts", "./tests/**/*.ts"],
 }


### PR DESCRIPTION
Allow passing `?presign={signature params}` to work around lambda not allowing the pre-soign params directly.