### PR TITLE
Fix outdir including src

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
 		"outDir": "dist"
 	},
 	"exclude": ["node_modules"],
-	"include": ["./src/**/*.ts", "./*.d.ts", "./tests/**/*.ts"],
+	"include": ["./src/**/*.ts", "./*.d.ts"],
 }


### PR DESCRIPTION
Adding the "tests" directory to the "include" in tsconfig changes the output structure. Because we have `tsconfig.test.json`, this include is not actually needed.
