### PR TITLE
Fix double-decode on presigm param

### DIFF
--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -33,7 +33,7 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 	// If there is a presign param, we need to decode it and add it to the args. This is to provide a secondary way to pass pre-sign params,
 	// as using them in a Lambda function URL invocation will trigger a Lambda error.
 	if ( args.presign ) {
-		const presignArgs = new URLSearchParams( decodeURIComponent( args.presign ) );
+		const presignArgs = new URLSearchParams( args.presign );
 		for ( const [ key, value ] of presignArgs.entries() ) {
 			args[ key as keyof Args ] = value;
 		}

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -95,7 +95,7 @@ test( 'Test get private upload with presign params', async () => {
 		'headers': {
 		},
 		'queryStringParameters': {
-			presign: encodeURIComponent( new URLSearchParams( presignParams ).toString() ),
+			presign: new URLSearchParams( presignParams ).toString(),
 		},
 		'isBase64Encoded': false,
 	};


### PR DESCRIPTION
This was only passing the tests because we incorrectly were double-encoding the presigned params too.

See https://github.com/humanmade/product-dev/issues/1536