### PR TITLE
Add Referer header support to S3 requests

### DIFF
--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -24,12 +24,16 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 		'X-Amz-Expires'?: string;
 		'presign'?: string,
 		key: string;
+		referer?: string;
 	};
 	args.key = key;
 	if ( typeof args.webp === 'undefined' ) {
 		args.webp = !! ( event.headers && Object.keys( event.headers ).find( key => key.toLowerCase() === 'x-webp' ) );
 	}
-
+	const refererHeaderKey = Object.keys(event.headers || {}).find(h => h.toLowerCase() === 'referer');
+	if (refererHeaderKey) {
+			args.referer = event.headers[refererHeaderKey];
+	}
 	// If there is a presign param, we need to decode it and add it to the args. This is to provide a secondary way to pass pre-sign params,
 	// as using them in a Lambda function URL invocation will trigger a Lambda error.
 	if ( args.presign ) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,6 +24,7 @@ export interface Args {
 	'X-Amz-Signature'?: string;
 	'X-Amz-Date'?: string;
 	'X-Amz-Security-Token'?: string;
+	referer?: string;
 }
 
 export type Config = S3ClientConfig & { bucket: string };
@@ -55,6 +56,10 @@ export async function getS3File( config: Config, key: string, args: Args ): Prom
 			 * @param request
 			 */
 			sign: async request => {
+				if (args.referer) {
+					request.headers = request.headers || {};
+					request.headers['referer'] = args.referer;
+				}
 				if ( ! args['X-Amz-Algorithm'] ) {
 					return request;
 				}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -57,7 +57,8 @@ export async function getS3File( config: Config, key: string, args: Args ): Prom
 			 */
 			sign: async request => {
 				if ( ! args['X-Amz-Algorithm'] ) {
-					// Add referer to the request headers on non-signed requests
+					// Add referer to the request headers on non-presigned URLs
+					// Presigned URLs works without the referer header
 					if (args.referer) {
 						request.headers = request.headers || {};
 						request.headers['referer'] = args.referer;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -56,11 +56,12 @@ export async function getS3File( config: Config, key: string, args: Args ): Prom
 			 * @param request
 			 */
 			sign: async request => {
-				if (args.referer) {
-					request.headers = request.headers || {};
-					request.headers['referer'] = args.referer;
-				}
 				if ( ! args['X-Amz-Algorithm'] ) {
+					// Add referer to the request headers on non-signed requests
+					if (args.referer) {
+						request.headers = request.headers || {};
+						request.headers['referer'] = args.referer;
+					}
 					return request;
 				}
 				const presignedParamNames = [


### PR DESCRIPTION
This PR updates the `getS3File` function to support forwarding the `Referer` header to S3 when present in the original request to the Lambda.

This makes it compatible with S3 bucket policies that require `aws:Referer`

Presigned URLs remain unchanged, since access is already authorized by the permissions of the user or role that generated the signature.