### PR TITLE
Add error checking for invalid signatures

### DIFF
--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -49,8 +49,10 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 	try {
 		s3_response = await getS3File( config, key, args );
 	} catch ( e: any ) {
+		const errorCode = e.Code || e.name || 'Unknown';
+
 		// An AccessDenied error means the file is either protected, or doesn't exist.
-		if ( e.Code === 'AccessDenied' ) {
+		if ( errorCode === 'AccessDenied' || errorCode === 'NoSuchKey' ) {
 			const metadata = {
 				statusCode: 404,
 				headers: {
@@ -62,6 +64,23 @@ const streamify_handler: StreamifyHandler = async ( event, response ) => {
 			response.end();
 			return;
 		}
+
+		// Log details for signature and auth errors to aid debugging.
+		console.error( `S3 error fetching key "${ key }": ${ errorCode }`, e.message || e );
+
+		if ( errorCode === 'SignatureDoesNotMatch' || errorCode === 'InvalidSignature' ) {
+			const metadata = {
+				statusCode: 403,
+				headers: {
+					'Content-Type': 'text/html',
+				},
+			};
+			response = awslambda.HttpResponseStream.from( response, metadata );
+			response.write( 'Signature error.' );
+			response.end();
+			return;
+		}
+
 		throw e;
 	}
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,6 +24,7 @@ export interface Args {
 	'X-Amz-Signature'?: string;
 	'X-Amz-Date'?: string;
 	'X-Amz-Security-Token'?: string;
+	'X-Amz-S3-Host'?: string;
 	referer?: string;
 }
 
@@ -90,6 +91,14 @@ export async function getS3File( config: Config, key: string, args: Args ): Prom
 						headers[header] = request.headers[header];
 					}
 				}
+
+				// Override the host header to match the original S3 signing host.
+				// The presigned URL was signed for a specific S3 endpoint host, and the
+				// request must use that same host for S3 to validate the signature.
+				if ( args['X-Amz-S3-Host'] && signedHeaders.includes( 'host' ) ) {
+					headers['host'] = args['X-Amz-S3-Host'];
+				}
+
 				request.query = presignedParams;
 
 				request.headers = headers;


### PR DESCRIPTION
Add error checking for invalid signatures and log S3 errors with more detail to aid debugging.

Pass the original S3 signing host in a custom header to ensure signature validation works correctly for private objects.

Addresses https://github.com/humanmade/altis-media/issues/162