### PR TITLE
Fix awslambda mock timing for ESM test imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ export default {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
 	testMatch: ['<rootDir>/tests/**/test-*.ts'],
+	setupFiles: ['<rootDir>/tests/setup.ts'],
 	extensionsToTreatAsEsm: ['.ts'],
 	transform: {
 		'^.+\\.tsx?$': [

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,24 @@
+/**
+ * Jest setup file to mock the AWS Lambda runtime global `awslambda`.
+ * This must run before test modules are imported so that
+ * lambda-handler.ts can call awslambda.streamifyResponse() at module scope.
+ */
+global.awslambda = {
+	/**
+	 *
+	 * @param handler
+	 */
+	streamifyResponse( handler: StreamifyHandler ): StreamifyHandler {
+		return handler;
+	},
+	HttpResponseStream: {
+		/**
+		 * @param stream The response stream.
+		 * @param metadata The metadata for the response.
+		 */
+		from( stream: ResponseStream, metadata: any ): ResponseStream {
+			stream.metadata = metadata;
+			return stream;
+		},
+	},
+};

--- a/tests/test-lambda.ts
+++ b/tests/test-lambda.ts
@@ -52,22 +52,3 @@ class TestResponseStream {
 	}
 }
 
-global.awslambda = {
-	/**
-	 *
-	 * @param handler
-	 */
-	streamifyResponse( handler: StreamifyHandler ): StreamifyHandler {
-		return handler;
-	},
-	HttpResponseStream: {
-		/**
-		 * @param stream The response stream.
-		 * @param metadata The metadata for the response.
-		 */
-		from( stream: TestResponseStream, metadata ) : TestResponseStream {
-			stream.metadata = metadata;
-			return stream;
-		},
-	},
-};


### PR DESCRIPTION
## Summary

- Moves the `global.awslambda` mock from `test-lambda.ts` into a dedicated Jest `setupFiles` script (`tests/setup.ts`) so it runs **before** any test module is imported
- `awslambda.streamifyResponse()` is called at module scope in `lambda-handler.ts`, and with ESM the import evaluates before any code in the test file — so the inline mock was a race condition
- The dependency updates in PR #594 changed evaluation timing, surfacing this latent bug

## Test plan

- [x] `npx jest tests/test-lambda.ts` passes locally
- [x] CI tests pass on this branch
- [ ] PR #594 can be rebased on top of this to verify its tests also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)