### PR TITLE
Opt out of S3 SDK default integrity protection in getS3File

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -50,6 +50,11 @@ function clamp( val: number | string, min: number, max: number ): number {
 export async function getS3File( config: Config, key: string, args: Args ): Promise<GetObjectCommandOutput> {
 	const s3 = new S3Client( {
 		...config,
+		// Opt out of default integrity protection (WHEN_SUPPORTED, added in
+		// @aws-sdk/client-s3 ~3.730). The auto-added checksum headers/query
+		// params break our reuse of the caller's presigned signature below.
+		requestChecksumCalculation: 'WHEN_REQUIRED',
+		responseChecksumValidation: 'WHEN_REQUIRED',
 		signer: {
 			/**
 			 *

--- a/tests/test-private-upload.ts
+++ b/tests/test-private-upload.ts
@@ -14,6 +14,8 @@ import { Args } from '../src/lib';
 async function getPresignedUrlParams( key: string ) : Promise<Args> {
 	const client = new S3Client( {
 		region: process.env.S3_REGION,
+		requestChecksumCalculation: 'WHEN_REQUIRED',
+		responseChecksumValidation: 'WHEN_REQUIRED',
 	} );
 	const command = new GetObjectCommand( {
 		Bucket: process.env.S3_BUCKET,


### PR DESCRIPTION
## Summary

Pin `requestChecksumCalculation` / `responseChecksumValidation` to `WHEN_REQUIRED`
on the S3 client used by `getS3File` (and the matching test client) so that
incoming presigned-URL requests continue to verify against S3 once the AWS SDK
is upgraded.

This is a prerequisite for #613 (the dependabot bump of `@aws-sdk/client-s3` /
`@aws-sdk/s3-request-presigner` from `3.712` → `3.1036`). Around `3.730` the
SDK flipped the default for both flags from `WHEN_REQUIRED` to `WHEN_SUPPORTED`,
which auto-adds checksum-related headers and pulls them into
`X-Amz-SignedHeaders`. The custom signer in `src/lib.ts` reuses a caller-
supplied presigned signature, so any extra signed headers added by middleware
make the canonical request diverge from what was signed and S3 rejects the
request with `SignatureDoesNotMatch`. Reproduced on PR #613 — both
`Test get private upload` cases failed there with that error.

The change is harmless on the current SDK (`3.712`) — the config keys exist
and the values are already the runtime defaults. After this lands, #613 can
be merged without code changes (just a rebase).

## Why two files

- `src/lib.ts` — the lambda's outbound S3 call.
- `tests/test-private-upload.ts` — the test generates the presigned URL with
  the same SDK as the lambda. Without the matching opt-out the test side
  signs against headers the lambda side won't include, so the test still
  fails after only fixing `lib.ts`.

## Impact on other Tachyon clients

Audited the three known consumers of presigned-URL flow → no changes needed:

- **`tachyon-plugin`** (`tachyon.php:61-73`) — only forwards existing
  `X-Amz-*` query params, never signs.
- **`s3-uploads`** (`inc/class-plugin.php:606-615`) — signs via
  `aws/aws-sdk-php` `3.371`. PHP SDK presign for `GetObject` produces
  `X-Amz-SignedHeaders=host` only; `ChecksumMode` is opt-in (only set inside
  the multipart downloader). Tachyon's signer filters to `host`, signature
  matches.
- **Altis private uploads** (`altis-media`
  `issue-162-default-private-uploads-2`,
  `inc/private_media/signed-urls.php`) — does not sign itself; routes
  attachment URLs through `wp_get_attachment_url()` (signed by S3 Uploads,
  see above) and `tachyon_url()`. The `rewrite_presigned_url_to_canonical_s3`
  filter only swaps the host on non-image responses.

So the opt-out is sufficient for production traffic. The test-side change is
only relevant because the JS SDK is what generates the URL in the unit test;
real callers don't hit the new SDK behavior.

## Test plan

- [x] `npx tsc --noEmit` clean on master + this change (no new SDK options
      missing on `3.712`).
- [ ] Pre-merge CI on this branch with `S3_BUCKET=testtachyonbucket` —
      same suite that's been passing on `test/pr-613-fix` (verified there
      with the SDK upgraded; identical code change here).
- [ ] After merge, rebase #613 — `test-private-upload.ts` should now pass
      against the upgraded SDK.